### PR TITLE
Fix code scanning alert no. 17: Incomplete URL substring sanitization

### DIFF
--- a/packages/backend/src/core/entities/DriveFileEntityService.ts
+++ b/packages/backend/src/core/entities/DriveFileEntityService.ts
@@ -4,6 +4,7 @@
  */
 
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { URL } from 'url';
 import { In } from 'typeorm';
 import { generateImageUrl } from '@imgproxy/imgproxy-node';
 import { DI } from '@/di-symbols.js';
@@ -171,7 +172,15 @@ export class DriveFileEntityService {
 		}
 
 		// Handle the general case where no specific mode is required
-		const isSafeCDNUrl = (url: string) => url.startsWith('https://s3.plasmatrap.com');
+		const isSafeCDNUrl = (url: string) => {
+			try {
+				const parsedUrl = new URL(url);
+				const allowedHosts = ['s3.plasmatrap.com'];
+				return allowedHosts.includes(parsedUrl.host);
+			} catch (e) {
+				return false;
+			}
+		};
 
 		// Return the direct URL if it's secure and available
 		if (file.url && isSafeCDNUrl(file.url)) {


### PR DESCRIPTION
Fixes [https://github.com/PrivateGER/Sharkey/security/code-scanning/17](https://github.com/PrivateGER/Sharkey/security/code-scanning/17)

To fix the problem, we need to parse the URL and check its host explicitly against a whitelist of allowed hosts. This ensures that the URL is genuinely from the allowed domain and not a maliciously crafted one. We will use the `url` module from Node.js to parse the URL and extract the host for comparison.

1. Import the `url` module from Node.js.
2. Define a whitelist of allowed hosts.
3. Parse the URL and extract the host.
4. Check if the extracted host is in the whitelist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
