### PR TITLE
Fix jsonLdService method call in ApRendererService

### DIFF
--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -819,7 +819,7 @@ export class ApRendererService {
 
 		const keypair = await this.userKeypairService.getUserKeypair(user.id);
 
-		activity = await this.jsonLdService.signRsaSignature2017(activity, keypair.privateKey, `${this.config.url}/users/${user.id}#main-key`);
+		activity = await this.jsonLdService.use().signRsaSignature2017(activity, keypair.privateKey, `${this.config.url}/users/${user.id}#main-key`);
 
 		return activity;
 	}


### PR DESCRIPTION
## What
Updated the `jsonLdService.signRsaSignature2017()` method call to use the `.use()` accessor pattern in the ActivityPub renderer service.

## Why
The `jsonLdService` appears to require using the `.use()` method to access its functionality, likely due to a service initialization or dependency injection pattern. This change ensures the method is called correctly on the service instance.

## Additional info
- Minimal change affecting only the ActivityPub signature generation flow
- No functional behavior change, only correcting the API usage pattern

https://claude.ai/code/session_01JzqoS7cjvodFiWW6qZxyXL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to signature handling in ActivityPub processing. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->