### PR TITLE
fix(backend): restore scoped global antenna access

### DIFF
--- a/packages/backend/src/const.ts
+++ b/packages/backend/src/const.ts
@@ -134,6 +134,7 @@ export const permissions = [
 	'read:admin:abuse-report:notification-recipient',
 	'write:admin:abuse-report:notification-recipient',
 	'write:admin:send-email',
+	'read:admin:antennas',
 	'read:admin:server-info',
 	'read:admin:show-moderation-log',
 	'read:admin:show-user',

--- a/packages/backend/src/server/api/endpoints/admin/antennas/global.ts
+++ b/packages/backend/src/server/api/endpoints/admin/antennas/global.ts
@@ -14,7 +14,6 @@ export const meta = {
 
 	requireCredential: true,
 	requireAdmin: true,
-	secure: true,
 	kind: 'read:admin:antennas',
 
 	res: {

--- a/packages/backend/test/e2e/antennas.ts
+++ b/packages/backend/test/e2e/antennas.ts
@@ -8,6 +8,7 @@ process.env.NODE_ENV = 'test';
 import * as assert from 'assert';
 import {
 	api,
+	createAppToken,
 	failedApiCall,
 	post,
 	role,
@@ -134,6 +135,51 @@ describe('アンテナ', () => {
 		}
 	});
 
+	test('admin/antennas/global accepts a scoped API token', async () => {
+		const antenna = await successfulApiCall({
+			endpoint: 'antennas/create',
+			parameters: { ...defaultParam, useGlobalRelay: true },
+			user: alice,
+		});
+		const token = await createAppToken(root, ['read:admin:antennas']);
+
+		const response = await successfulApiCall({
+			endpoint: 'admin/antennas/global',
+			parameters: {},
+			user: { token },
+		});
+
+		assert.ok(response.some(globalAntenna => globalAntenna.id === antenna.id));
+	});
+
+	test('admin/antennas/global rejects an API token without its scope', async () => {
+		const token = await createAppToken(root, ['read:account']);
+
+		await failedApiCall({
+			endpoint: 'admin/antennas/global',
+			parameters: {},
+			user: { token },
+		}, {
+			status: 403,
+			code: 'PERMISSION_DENIED',
+			id: '1370e5b7-d4eb-4566-bb1d-7748ee6a1838',
+		});
+	});
+
+	test('admin/antennas/global rejects a scoped non-admin API token', async () => {
+		const token = await createAppToken(alice, ['read:admin:antennas']);
+
+		await failedApiCall({
+			endpoint: 'admin/antennas/global',
+			parameters: {},
+			user: { token },
+		}, {
+			status: 403,
+			code: 'ROLE_PERMISSION_DENIED',
+			id: 'c3d38592-54c0-429d-be96-5636b0431a61',
+		});
+	});
+
 	//#region 作成(antennas/create)
 
 	test('が作成できること、キーが過不足なく入っていること。', async () => {
@@ -160,6 +206,7 @@ describe('アンテナ', () => {
 			withReplies: false,
 			excludeBots: false,
 			localOnly: false,
+			useGlobalRelay: false,
 			notify: false,
 		};
 		assert.deepStrictEqual(response, expected);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission support for reading global antenna settings.
  * Authorized administrators can access global antenna data using appropriately scoped access tokens.

* **Bug Fixes**
  * Corrected access handling so insufficient permissions or roles are rejected appropriately.
  * Global antenna responses now consistently include the global relay setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->